### PR TITLE
Refactor schema

### DIFF
--- a/src/resconfig/__init__.py
+++ b/src/resconfig/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "Taro Sato"
 __author_email__ = "okomestudio@gmail.com"
-__version__ = "0.2.1.dev0"
+__version__ = "0.2.2.dev0"
 __license__ = "MIT"

--- a/src/resconfig/resconfig.py
+++ b/src/resconfig/resconfig.py
@@ -10,6 +10,7 @@ from .typing import Any
 from .typing import Callable
 from .typing import Key
 from .typing import Optional
+from .utils import apply_schema
 from .utils import expand
 from .utils import isdict
 from .utils import merge
@@ -75,8 +76,8 @@ class _Reloadable:
 
     def _reload(self, reloaders, schema, key, action, oldval, newval):
         if key in reloaders and self.reloaderkey in reloaders[key]:
-            # TODO: Apply schema to both oldval and newval
-
+            oldval = apply_schema(schema, oldval)
+            newval = apply_schema(schema, newval)
             for func in reloaders[key][self.reloaderkey]:
                 func(action, oldval, newval)
 
@@ -170,14 +171,7 @@ class ResConfig(_Reloadable, _IO):
                     raise
                 else:
                     return default
-
-        if not isdict(s):
-            try:
-                return s(d)
-            except Exception:
-                raise ValueError(f"{d!r} cannot be converted to {s}")
-        else:
-            return d
+        return apply_schema(s, d)
 
     def _update(
         self, conf: dict, newconf: dict, reloaders: dict, schema: dict, reload=True

--- a/src/resconfig/utils.py
+++ b/src/resconfig/utils.py
@@ -63,3 +63,20 @@ def expand(d: dict) -> dict:
             dnew[key] = v
 
     return new
+
+
+def apply_schema(schema, config):
+    if isdict(config):
+        newconfig = {}
+        for key, value in config.items():
+            newconfig[key] = apply_schema(schema.get(key, {}), value)
+        return newconfig
+
+    if not isdict(schema):
+        try:
+            v = schema(config)
+        except Exception:
+            raise ValueError(f"{config!r} cannot be converted to {schema}")
+    else:
+        v = config
+    return v

--- a/tests/resconfig/test_utils.py
+++ b/tests/resconfig/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from resconfig.utils import apply_schema
 from resconfig.utils import expand
 from resconfig.utils import merge
 
@@ -40,3 +41,20 @@ class TestExpand:
         with pytest.raises(ValueError) as exc:
             expand(trial)
         assert "Cannot upcast" in str(exc)
+
+
+class TestApplySchema:
+    @pytest.mark.parametrize(
+        "value, schema, expected",
+        [
+            ("text", list, ["t", "e", "x", "t"]),
+            (
+                {"a": {"b": {"c": "123", "d": "text"}}},
+                {"a": {"b": {"c": int}}},
+                {"a": {"b": {"c": 123, "d": "text"}}},
+            ),
+        ],
+    )
+    def test(self, value, schema, expected):
+        result = apply_schema(schema, value)
+        assert result == expected


### PR DESCRIPTION
This PR applies schema more consistently where config values need to be obtained (e.g., `get` and reloaders).